### PR TITLE
공연자&공연장 공연 준비 페이지 API 연결 확인

### DIFF
--- a/src/components/booking/popup_payment.jsx
+++ b/src/components/booking/popup_payment.jsx
@@ -71,6 +71,7 @@ const Popup_payment = ({name, count, price, bookName, phoneNum, prev, next, bank
     // 전체 동의 확인 
     const checkComplete = () => {
         if (complete) {
+            
             next();
         } else {
             alert("전체 동의해주셔야 예매가 가능합니다.");

--- a/src/components/concert_Ready/readyHeader.jsx
+++ b/src/components/concert_Ready/readyHeader.jsx
@@ -1,11 +1,46 @@
 import "../../styles/Eojin/readyHeader.css"
+import { useLocation } from "react-router-dom";
+import { useState, useEffect } from "react";
 
 const ReadyHeader = ({ step, onClick }) => {
+    const [date, setDate] = useState('');
+    const [dDay, setDDay] = useState('');
+    const location = useLocation();
+    console.log("location:", location);
+    const spaceApplyId = location.state.id || "받아오지 못함";
+    console.log("spaceApplyId:", spaceApplyId);
+
+    // 다운로드 양식 받기 
+    async function getDay() {
+        const token = sessionStorage.getItem("accessToken");
+        try {
+            const res = await axios.get(
+                `https://showhoo.site/${spaceApplyId}/show-date`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },           
+                }
+            );
+            const Date = res.data.result.date;
+            setDate(Date);
+            const DDay = res.data.result.dday;
+            setDDay(DDay);
+            console.log("결과:", res.data.isSuccess);
+        } catch (error) {
+            console.log("Error:", error);
+        }
+    };
+
+    useEffect(()=>{
+        getDay();
+    }, []);
+
     return (
         <div>
             <div className="ReadyHeader_Dday">
-                <h3>D-9</h3>
-                <p>2024-08-13</p>
+                <h3>{dDay}</h3>
+                <p>{date}</p>
             </div>
             <div className="Level">
                 <div className={`Circle QCircle_${step}`} onClick={() => onClick(1)}>

--- a/src/components/concert_Ready/readyQsheet.jsx
+++ b/src/components/concert_Ready/readyQsheet.jsx
@@ -12,6 +12,7 @@ import rentalTime from "../../assets/img_Ready/rentalTime.svg";
 import plus from "../../assets/img_Ready/plus.svg";
 
 const ReadyQsheet = ({ nextStep, check, setShowId, showId }) => {
+
     const location = useLocation();
     console.log("location:", location);
     const spaceApplyId = location.state.id || "받아오지 못함";
@@ -116,6 +117,8 @@ const ReadyQsheet = ({ nextStep, check, setShowId, showId }) => {
         getUploadData()
     },[setListForm, addOrderForm, rentalTimeForm])
 
+
+    
     // 작성된 큐시트 다운 받기 
     async function getDownloadData() {
         if (showId) {

--- a/src/components/concert_Ready/readyRequest.jsx
+++ b/src/components/concert_Ready/readyRequest.jsx
@@ -10,7 +10,7 @@ const ReadyRequest = ({ preStep, nextStep }) => {
     const [error, setError] = useState(null);
 
     // 작성된 요청사항 API 연결 
-    const showId = 1;
+    const showId = 8;
 
     async function getDownloadData() {
         const token = sessionStorage.getItem("accessToken");
@@ -23,7 +23,7 @@ const ReadyRequest = ({ preStep, nextStep }) => {
                     },           
                 }
             );
-            const getReq = res.data.result;
+            const getReq = res.data.result.requirement;
             setRequest(getReq);
             setLoading(false);
             console.log("다운로드 양식 보기", res.data);

--- a/src/components/perform_Ready/Datepicker/calender.css
+++ b/src/components/perform_Ready/Datepicker/calender.css
@@ -80,6 +80,8 @@
     width: 40% !important;
     padding: 5px !important;
     box-sizing: border-box !important;
+    display: flex;
+    flex-direction: column;
 }
 
 .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box {
@@ -91,6 +93,8 @@
 .react-datepicker__header--time{
     border-bottom: 1px solid #aeaeae !important;
     padding-right: 20px !important;
+    display: flex !important;
+    flex-direction: column !important;
 }
 
 /* Time */
@@ -103,6 +107,7 @@
 .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item {
     display: flex !important;
     justify-content: center !important;
+    flex-direction: column !important;
     align-items: center !important;
     font-weight:400 !important;
     padding: 0 5px !important;
@@ -127,4 +132,25 @@
     font-weight:400 !important;
     padding: 0 5px !important;
     margin: 10px 5px !important;
+}
+
+li.react-datepicker__time-list-item {
+    height: 30px !important;
+    padding: 5px 10px !important;
+}
+
+.react-datepicker__time-box ul {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 0 auto;
+}
+
+.react-datepicker__time-box ul li {
+    display: flex;
+    justify-content: center;
+    width: 70px;
+    box-sizing: border-box;
+    padding: 0 5px !important;
+    margin: 10px auto !important;
 }

--- a/src/components/perform_Ready/readyHeader.jsx
+++ b/src/components/perform_Ready/readyHeader.jsx
@@ -1,11 +1,54 @@
 import "../../styles/Eojin/readyHeader.css"
+import { useLocation } from "react-router-dom";
+import { useState, useEffect } from "react";
+import axios from "axios";
 
 const ReadyHeader = ({ step, onClick }) => {
+    const [date, setDate] = useState('');
+    const [dDay, setDDay] = useState('');
+    /*
+    const location = useLocation();
+    console.log("location:", location);
+    const spaceApplyId = location.state.id || "받아오지 못함";
+    console.log("spaceApplyId:", spaceApplyId);
+    */
+
+    const spaceApplyId = 2;
+    
+
+    // 다운로드 양식 받기 
+    async function getDay() {
+        const token = sessionStorage.getItem("accessToken");
+        try {
+            const res = await axios.get(
+                `https://showhoo.site/${spaceApplyId}/show-date`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },           
+                }
+            );
+            const Date = res.data.result.date;
+            setDate(Date);
+            console.log(date);
+            const DDay = res.data.result.dday;
+            setDDay(DDay);
+            console.log(dDay);
+            console.log("결과:", res.data.isSuccess);
+        } catch (error) {
+            console.log("Error:", error);
+        }
+    };
+
+    useEffect(()=>{
+        getDay();
+    }, []);
+
     return (
         <div className="ReadyHeader">
             <div className="ReadyHeader_Dday">
-                <h3>D-9</h3>
-                <p>2024-08-13</p>
+                <h3>{dDay}</h3>
+                <p>{date}</p>
             </div>
             <div className="Level">
                 <div className={`Circle QCircle_${step}`} onClick={() => onClick(1)}>

--- a/src/components/perform_Ready/readyPoster.jsx
+++ b/src/components/perform_Ready/readyPoster.jsx
@@ -19,9 +19,11 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
   const [name, setName] = useState("");   // 공연명 
   const [date, setDate] = useState("");   // 공연 날짜
   const [time, setTime] = useState("");   // 공연 시간
+  const [concertDate, setConcertDate] = useState("");
   const [runningTime, setRunningTime] = useState("");   // 러닝 타임
   const [cancelDate, setCancelDate] = useState("");   // 예매취소기한 날짜
   const [cancelTime, setCancelTime] = useState("");   // 예매취소기한 시간
+  const [cancelDateTime, setCancelDateTime] = useState("");
 
   // CKEditor에서 받아올 데이터 
   const [text, setText] = useState('');   // 상세내용 text 
@@ -37,7 +39,6 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
     const file = event.target.files[0];
     if (file && (file.type === "image/jpeg" || file.type === "image/png")) {
         setImage(file);
-        getPosterUrl();
     } else {
         alert("Only JPG, JPEG, and PNG files are allowed.");
     }
@@ -76,12 +77,20 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
     }
   };
 
+  useEffect(() => {
+    if(image) {
+      getPosterUrl();
+    } else {
+      alert("파일이 비어있어요!");
+    }
+  },[image]);
+
  // 날짜 변환 함수 
   const formatDate = (data) => {
     // 날짜를 'YYYY-MM-DD' 형식으로 변환
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
-    const day = String(date.getDate()).padStart(2, '0');
+    const year = data.getFullYear();
+    const month = String(data.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
+    const day = String(data.getDate()).padStart(2, '0');
 
     return `${year}-${month}-${day}`;
   }
@@ -94,11 +103,22 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
     return `${hours}:${minutes}`;
   }
 
+  const formatDateTime = (data) => {
+    const year = data.getFullYear();
+    const month = String(data.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
+    const day = String(data.getDate()).padStart(2, '0');
+    const hours = String(data.getHours()).padStart(2, '0');
+    const minutes = String(data.getMinutes()).padStart(2, '0');
+
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  }
+
   // 공연 날짜 정하는 함수 
   const handleDateChange1 = (data) => {
     setSelectedDate1(data);
     setDate(formatDate(data));
     setTime(formatTime(data));
+    setConcertDate(formatDateTime(data));
     setIsDatePickerOpen1(false); // 선택 후 DatePicker 닫기
     console.log(date, time);
   };
@@ -107,7 +127,8 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
   const handleDateChange2 = (data) => {
     setSelectedDate2(data);
     setCancelDate(formatDate(data));
-    setCancelTime(formatTime(data))
+    setCancelTime(formatTime(data));
+    setCancelDateTime(formatDateTime(data));
     setIsDatePickerOpen2(false); // 선택 후 DatePicker 닫기
     console.log(cancelDate, cancelTime);
   };
@@ -124,7 +145,7 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
 
 
   // 공연 포스터 및 정보에 대한 데이터 API 연결
-  const performerProfileId = 1;
+  const performerProfileId = 11;
 
   const uploadInf = async () => {
     const token = sessionStorage.getItem("accessToken");
@@ -173,7 +194,7 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
   };
 
   // 서버에 상세내용 보내기 API 연결 
-  const showId = 1;
+  const showId = 8;
 
   const uploadDes = async () => {
     const token = sessionStorage.getItem("accessToken");
@@ -218,7 +239,7 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
           <div className="Poster">
             {!image && (
               <div className="upload-text">
-                <p>포스트를 추가하세요.</p>
+                <p>포스터를 추가하세요.</p>
                 <p>
                   <span className="upload-link" onClick={handleUploadClick}>
                     기기에서 업로드
@@ -252,7 +273,7 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
             onChange={(e) => setName(e.target.value)}
           />
           <div className="inf_date" onClick={toggleDatePicker1}>
-            {selectedDate1 ? <p>{date} {time}</p> : <p>공연 날짜</p>}
+            {selectedDate1 ? <p>{concertDate}</p> : <p>공연 날짜</p>}
             <img className="arrow" src={arrow} alt="arrow" />
           </div>
           {isDatePickerOpen1 && (
@@ -269,7 +290,7 @@ const ReadyPoster = ({ preStep, nextStep, check }) => {
             onChange={(e) => setRunningTime(e.target.value)}
           />
           <div className="inf_cancel" onClick={toggleDatePicker2}>
-            {selectedDate2 ? <p>{cancelDate} {cancelTime}</p> : <p>예매 취소 기한</p>}
+            {selectedDate2 ? <p>{cancelDateTime}</p> : <p>예매 취소 기한</p>}
             <img className="arrow" src={arrow} alt="arrow" />
           </div>
           {isDatePickerOpen2 && (

--- a/src/components/perform_Ready/readyQsheet.jsx
+++ b/src/components/perform_Ready/readyQsheet.jsx
@@ -7,8 +7,8 @@ import Button from "../common/Button";
 import ReadySubmit from "./readySubmit";
 import ReadyDownload from "./readyDownload";
 
-import setList from "../../assets/img_Ready/setList.svg";
-import rentalTime from "../../assets/img_Ready/rentalTime.svg";
+import setListImg from "../../assets/img_Ready/setList.svg";
+import rentalTimeImg from "../../assets/img_Ready/rentalTime.svg";
 import plus from "../../assets/img_Ready/plus.svg";
 
 const ReadyQsheet = ({ nextStep, check }) => {
@@ -30,7 +30,7 @@ const ReadyQsheet = ({ nextStep, check }) => {
     const [ rentalTime, setRentalTime ] = useState('');
     const [ addOrder, setAddOrder ] = useState('');
 
-    const showId = 6;
+    const showId = 8;
 
     // 다운로드 양식 받기 
     async function getDownloadData() {
@@ -55,12 +55,12 @@ const ReadyQsheet = ({ nextStep, check }) => {
     useEffect(() => {
         getDownloadData();
     }, []);
-
+    /*
     const location = useLocation();
     console.log("location:", location);
     const spaceApplyId = location.state.id || "받아오지 못함";
     console.log("spaceApplyId:", spaceApplyId);
-
+    */
     // 큐시트 업로드 하기 
     async function getUploadData() {
         if (setList && addOrder && rentalTime) {
@@ -144,8 +144,8 @@ const ReadyQsheet = ({ nextStep, check }) => {
                 <h4>다운로드</h4>
                 <p>대관을 위해 제출해야 할 신청서 및 양식을 다운로드하실 수 있습니다.</p>
                 <div className="download_container">
-                    <ReadyDownload text={"공연 셋리스트 양식"} id={"setList"} img={setList} url={urls.setListForm} />
-                    <ReadyDownload text={"대관 시간 양식"} id={"rentalTime"} img={rentalTime} url={urls.rentalTimeForm} />
+                    <ReadyDownload text={"공연 셋리스트 양식"} id={"setList"} img={setListImg} url={urls.setListForm} />
+                    <ReadyDownload text={"대관 시간 양식"} id={"rentalTime"} img={rentalTimeImg} url={urls.rentalTimeForm} />
                     <ReadyDownload text={"추가 주문 양식"} id={"plus"} img={plus} url={urls.addOrderForm} />
                 </div>
             </div>

--- a/src/components/perform_Ready/readyRequest.jsx
+++ b/src/components/perform_Ready/readyRequest.jsx
@@ -25,7 +25,7 @@ const ReadyRequest = ({ preStep, nextStep, check }) => {
         }
     };
 
-    const showId = 1;
+    const showId = 8;
 
     const uploadData = async () => {
         const token = sessionStorage.getItem("accessToken");

--- a/src/components/perform_Ready/readyTicket.jsx
+++ b/src/components/perform_Ready/readyTicket.jsx
@@ -12,7 +12,7 @@ const ReadyDetail = ({ preStep, nextStep }) => {
     const [perMaxticket, setPermaxticket] = useState(0);
 
     // 티켓 발행 등록 API 연결 
-    const showId = 1;
+    const showId = 8;
 
     const uploadTicket = async () => {
         const token = sessionStorage.getItem("accessToken");
@@ -75,14 +75,12 @@ const ReadyDetail = ({ preStep, nextStep }) => {
                                 className="bank" 
                                 type="text" 
                                 placeholder="은행명" 
-                                value="bank"
                                 onChange={(e) => setBank(e.target.value)} 
                             />
                             <input 
                                 className="accountHolder" 
                                 type="text" 
                                 placeholder="예금주" 
-                                name="accountHolder" 
                                 onChange={(e) => setAccountHolder(e.target.value)} 
                             />
                         </div>
@@ -90,7 +88,6 @@ const ReadyDetail = ({ preStep, nextStep }) => {
                             className="account" 
                             type="text" 
                             placeholder="계좌번호" 
-                            name="accountNum" 
                             onChange={(e) => setAccountNum(e.target.value)} 
                         />
                     </div>

--- a/src/styles/Eojin/readyPoster.css
+++ b/src/styles/Eojin/readyPoster.css
@@ -23,6 +23,15 @@ input::placeholder {
     font-size: 30px;
 }
 
+
+.Poster_inf > h4 {
+    margin: 15px 0;
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 30px;
+}
+
 .Poster_container > .Poster_img {
     width: 45%;
 }
@@ -67,7 +76,24 @@ input::placeholder {
     color: #0F0F0F;
 }
 
-.Poster > .upload-text .upload-link {
+.Poster > .upload-text {
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 16px;
+    display: flex;
+    margin: 0 auto;
+    align-items: center;
+    flex-direction: column;
+    text-align: center;
+    color: #0F0F0F;
+}
+
+.upload-text > p {
+    margin: 0 5px;
+}
+  
+.upload-text > p > .upload-link {
     font-family: 'Pretendard';
     font-style: normal;
     font-weight: 400;
@@ -76,10 +102,6 @@ input::placeholder {
     margin: 0 auto;
     align-items: center;
     text-align: center;
-    color: #0F0F0F;
-}
-  
-.upload-text > .upload-link {
     text-decoration: underline;
     color: blue;
     cursor: pointer;
@@ -166,7 +188,8 @@ input::placeholder {
     font-weight: 400;
     font-size: 17px;
     align-items: center;
-    color: #656565;;
+    color: #656565;
+    margin: 0;
 }
 
 .Poster_inf > .inf_runningTime {
@@ -208,7 +231,8 @@ input::placeholder {
     font-weight: 400;
     font-size: 17px;
     align-items: center;
-    color: #656565;;
+    color: #656565;
+    margin: 0;
 }
 
 .ReadyPoster > .Detail_Container {


### PR DESCRIPTION
**공연자&공연장 공연 준비 페이지 API 연결 확인**

1. 공연장 준비 페이지 
     - 큐시트 폼 업로드는 계속 서버 오류 
     - 임의의 데이터 넣어 다운로드 했을 때는 잘 넘어옴. => spaceId 가져오는 문제만 해결 하면 됨. 
2. 공연자 준비 페이지 
     - 큐시트는 똑같은 상황 (업로드 실패 & 다운로드 성공)
     - 요청사항 임의의 spaceId로 했을 때 데이터 잘 넘어가는 거 확인 완료 
     - 포스터, 공연정보, 세부사항, 티켓 부분은 업로드 잘 안됨. 
         => 업로드 할 때 performerProfileId가 필요한데.. 무슨 Id를 말하는 건지 잘 모르겠음. 
     - 공연 예매자 관리 페이지: 데이터 가져오는 방식 자체를 이해 못하고 있는 상황 